### PR TITLE
Fix some docs typos to avoid compilation errors

### DIFF
--- a/docs/ch2.md
+++ b/docs/ch2.md
@@ -14,7 +14,7 @@ To ensure clean code and easier readability, we are going to separate our compon
 
 > A presentational component is a "dumb" component that only receives data from its parent and should never change the data itself. They are be reusable and should only render the views. 
 
-Create a `src/container` folder. Create a `src/containers/Pokemon.js` file. 
+Create a `src/containers` folder. Create a `src/containers/Pokemon.js` file. 
 
 Import the following dependencies and create the Pokemon class that extends Component. 
 

--- a/docs/ch4.md
+++ b/docs/ch4.md
@@ -71,7 +71,7 @@ Insert your Router under the h1 tag and remove the Pokemon tag.
 
 You should be able to enter either path and it will show the right component. We want the user to be able to switch tabs between the Pokemon list and Pokedex instead of entering in the path. Let's create a Tabs component.
 
-Create a Tabs component in `src/components/Tabs`. Paste this into the Tabs component. 
+Create a Tabs component in `src/components/Tabs.js`. Paste this into the Tabs component. 
 
 ```
 import React, { Component } from 'react';
@@ -119,7 +119,7 @@ export default Tabs;
 Import the Tabs component into `src/App.js` below the imports.
 
 ```
-import Tabs from "./components/Tabs";
+import Tabs from "./components/Tabs.js";
 ```
 
 Insert the Tabs component above the first Route tag. 


### PR DESCRIPTION
* change mkdir command for `src/container` to `src/containers`
  in ch2.md

* change file creation for `src/components/Tabs` to
  `src/components/Tabs.js` in ch4.md. If there is no .js extension,
  an `InvalidCharacterError` will pop up at compile time in
  `src/index.js` related to ReactDOM.render().

* change Tabs import statement to reflect above change in ch4.md

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>